### PR TITLE
fix: reset version to 0.0.1 and document version bump requirement

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude",
-  "version": "2.0.0",
+  "version": "0.0.1",
   "description": "Add 'ultrawork' to any prompt for maximum parallel execution.",
   "author": {
     "name": "TechDufus",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,3 +149,20 @@ export ENABLE_LSP_TOOL=1  # Add to shell profile
 3. **PARALLELIZE** - Launch ALL independent Tasks in ONE message
 4. **TRACK** - TodoWrite is mandatory for non-trivial work
 5. **COMPLETE** - Cannot stop until all todos are done and validation passes
+
+## Development Guidelines
+
+### Version Bumping
+
+Claude Code caches plugins by version. **Any change to cached content requires a version bump** in `.claude-plugin/plugin.json`:
+
+| Change Type | Requires Version Bump |
+|-------------|----------------------|
+| Agents (add/modify/remove) | YES |
+| Hooks | YES |
+| Commands | YES |
+| Skills | YES |
+| CLAUDE.md | NO (not cached) |
+| README.md | NO |
+
+Forgetting to bump the version means users won't see your changes until they manually clear their cache.


### PR DESCRIPTION
## Summary

Claude Code caches plugins by version. The agent team refactor wasn't being picked up because the version stayed at 2.0.0 - cached old agents (deep-explorer, context-summarizer, parallel-implementer) were still being used instead of the new team (scout, librarian, architect, worker, scribe, validator).

Reset to 0.0.1 to invalidate caches and added development guidelines documenting when version bumps are required.