### PR TITLE
Migrate notepad workflow to /memory and add runtime load guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Ultrawork mode for maximum parallel execution with intelligent subagent use",
-    "version": "0.12.0"
+    "version": "0.12.1"
   },
   "plugins": [
     {
       "name": "oh-my-claude",
       "source": "./plugins/oh-my-claude",
       "description": "Add 'ultrawork' to any prompt for maximum parallel execution.",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "author": {
         "name": "TechDufus"
       },

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ Thumbs.db
 
 # Claude local settings
 .claude/settings.local.json
-.claude/notepads/
 
 # Node (if any)
 node_modules/

--- a/plugins/oh-my-claude/.claude-plugin/plugin.json
+++ b/plugins/oh-my-claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Add 'ultrawork' to any prompt for maximum parallel execution.",
   "author": {
     "name": "TechDufus",

--- a/plugins/oh-my-claude/CLAUDE.md
+++ b/plugins/oh-my-claude/CLAUDE.md
@@ -189,30 +189,14 @@ Context protection is always on. Ultrawork adds execution intensity.
 | Validation | When appropriate | REQUIRED before stopping |
 | Completion | End normally | Must output `<promise>DONE</promise>` |
 
-### External Memory (Notepad System)
+### External Memory
 
-For complex tasks, persist learnings to avoid losing context:
-
-| Notepad | Purpose | When to Use |
-|---------|---------|-------------|
-| `.claude/notepads/learnings.md` | Patterns discovered, gotchas found | After discovering something non-obvious |
-| `.claude/notepads/decisions.md` | Design decisions with rationale | After making architectural choices |
-| `.claude/notepads/issues.md` | Problems encountered, blockers | When hitting blockers or finding bugs |
-| `.claude/notepads/context.md` | Project-specific context | Key info for /prime recovery |
-
-**Entry Format:**
-```markdown
-## [YYYY-MM-DD HH:MM] {title}
-Source: {agent-name or "user"}
-
-{content}
-```
+Use Claude Code auto-memory for durable context via `/memory`.
 
 **Protocol:**
-- Write to notepads BEFORE context fills up
-- Read notepads when resuming work or after /prime
-- Include notepad wisdom in agent delegations
-- Agents should append findings, not overwrite
+- Save key decisions, learnings, and blockers with `/memory` before context fills up
+- Review relevant memory entries when resuming work or after `/prime`
+- Include important memory context in agent delegations
 
 ## Ultra Plan Mode
 

--- a/plugins/oh-my-claude/commands/prime.md
+++ b/plugins/oh-my-claude/commands/prime.md
@@ -169,7 +169,7 @@ Return `<github_analysis><none>No GitHub context available</none></github_analys
 1. `CLAUDE.md` - Look for "## Active Work" section
 2. `.claude/CLAUDE.md` - Project-specific instructions
 3. `TODO.md` or `TODO` - Tracked tasks
-4. `.claude/notepads/` - learnings.md, decisions.md, context.md
+4. Claude Code `/memory` - relevant persisted learnings, decisions, and context
 5. `git diff --name-only HEAD~5..HEAD 2>/dev/null | head -20`
 
 **Task-Focused Exploration** (if hint provided):
@@ -180,11 +180,11 @@ Return `<github_analysis><none>No GitHub context available</none></github_analys
 
 **Requirements**:
 - Active work description and phase from CLAUDE.md
-- Key learnings, decisions, context from notepads
+- Key learnings, decisions, and context from `/memory`
 - Primary directories and patterns from recent changes
 - Relevant files and conventions (if task hint provided)
 
-**XML Fields**: `active_work`, `notepad_context` (with learnings/decisions/context), `focus_areas`, `project_type`, `available_commands`, `task_exploration` (with relevant_files/implementation_summary/conventions)
+**XML Fields**: `active_work`, `memory_context` (with learnings/decisions/context), `focus_areas`, `project_type`, `available_commands`, `task_exploration` (with relevant_files/implementation_summary/conventions)
 
 ---
 

--- a/plugins/oh-my-claude/hooks/context_monitor.py
+++ b/plugins/oh-my-claude/hooks/context_monitor.py
@@ -128,7 +128,7 @@ def main() -> None:
         warning = (
             f"[CONTEXT CRITICAL: ~{usage_pct*100:.0f}% used]\n"
             f"Delegate large file reads and searches to preserve remaining context.\n"
-            f"Consider: (1) Delegate to subagents (2) Write to notepads (3) Summarize before continuing\n\n"
+            f"Consider: (1) Delegate to subagents (2) Use /memory for key context (3) Summarize before continuing\n\n"
             f"\"I'm almost done\" \u2192 70% full means context tax on every operation. Delegate now."
         )
         output_context("PostToolUse", warning)

--- a/plugins/oh-my-claude/hooks/safe_permissions.py
+++ b/plugins/oh-my-claude/hooks/safe_permissions.py
@@ -308,7 +308,7 @@ def is_path_in_project(path: str) -> bool:
         return False
 
 
-CLAUDE_INTERNAL_DIRS = (".claude/plans", ".claude/plans/drafts", ".claude/notepads", ".claude/tasks")
+CLAUDE_INTERNAL_DIRS = (".claude/plans", ".claude/plans/drafts", ".claude/tasks")
 
 
 def is_claude_internal_path(path: str) -> bool:
@@ -327,7 +327,7 @@ def is_claude_internal_path(path: str) -> bool:
     except (OSError, ValueError):
         return False
     for allowed_dir in CLAUDE_INTERNAL_DIRS:
-        # Match /.claude/plans/ (or /notepads/, /tasks/) anywhere in resolved path
+        # Match /.claude/plans/ (or /tasks/) anywhere in resolved path
         marker = os.sep + allowed_dir + os.sep
         if marker in resolved or resolved.endswith(os.sep + allowed_dir):
             return True

--- a/plugins/oh-my-claude/hooks/ultrawork_detector.py
+++ b/plugins/oh-my-claude/hooks/ultrawork_detector.py
@@ -816,13 +816,8 @@ When TRULY done: `<promise>DONE</promise>`
 
 ## EXTERNAL MEMORY
 
-| Notepad | Purpose |
-|---------|---------|
-| `.claude/notepads/learnings.md` | Patterns, gotchas |
-| `.claude/notepads/decisions.md` | Design decisions |
-| `.claude/notepads/issues.md` | Blockers |
-
-Write BEFORE context fills. Read when resuming.
+Use Claude Code auto-memory via `/memory` to persist decisions, learnings, and blockers.
+Write before context fills. Review relevant memory when resuming.
 
 Execute relentlessly until complete."""
 
@@ -1140,13 +1135,8 @@ When TRULY done: `<promise>DONE</promise>`
 
 ## EXTERNAL MEMORY
 
-| Notepad | Purpose |
-|---------|---------|
-| `.claude/notepads/learnings.md` | Patterns, gotchas |
-| `.claude/notepads/decisions.md` | Design decisions |
-| `.claude/notepads/issues.md` | Blockers |
-
-Write BEFORE context fills. Read when resuming.
+Use Claude Code auto-memory via `/memory` to persist decisions, learnings, and blockers.
+Write before context fills. Review relevant memory when resuming.
 
 Execute relentlessly until complete."""
 

--- a/tests/oh-my-claude/hooks/test_safe_permissions.py
+++ b/tests/oh-my-claude/hooks/test_safe_permissions.py
@@ -771,10 +771,8 @@ class TestWriteEditAutoApproval:
         [
             ".claude/plans/plan.md",
             ".claude/plans/drafts/plan.md",
-            ".claude/notepads/note.md",
             ".claude/tasks/team/task.json",
             "../../../../../.claude/plans/drafts/plan.md",
-            "../../.claude/notepads/note.md",
         ],
     )
     def test_claude_internal_paths_approved(self, path):
@@ -788,6 +786,8 @@ class TestWriteEditAutoApproval:
             ".env",
             "CLAUDE.md",
             ".claude/settings.json",
+            ".claude/notepads/note.md",
+            "../../.claude/notepads/note.md",
         ],
     )
     def test_non_internal_paths_not_approved(self, path):


### PR DESCRIPTION
## Summary
- Remove notepad-based memory workflow from plugin guidance and hook prompts.
- Standardize on Claude Code `/memory` for durable context instructions.
- Tighten permission behavior so `.claude/notepads/*` is no longer treated as an auto-approved internal path.
- Add maintainer runtime guidance for real Claude Code plugin load validation in `CONTRIBUTING.md`.

## Changes
- `plugins/oh-my-claude/CLAUDE.md`
  - Replaced External Memory notepad section with `/memory` guidance.
- `plugins/oh-my-claude/commands/prime.md`
  - Replaced `.claude/notepads` references with `/memory` and renamed `notepad_context` -> `memory_context`.
- `plugins/oh-my-claude/hooks/ultrawork_detector.py`
  - Replaced notepad instructions in injected contexts with `/memory` guidance.
- `plugins/oh-my-claude/hooks/context_monitor.py`
  - Updated context warning copy to recommend `/memory`.
- `plugins/oh-my-claude/hooks/safe_permissions.py`
  - Removed `.claude/notepads` from `CLAUDE_INTERNAL_DIRS`.
- `tests/oh-my-claude/hooks/test_safe_permissions.py`
  - Updated assertions: notepad paths are no longer internal/auto-approved.
- `CONTRIBUTING.md`
  - Added "Real Runtime Plugin Load Test" section with CLI command + log checks.
- `.gitignore`
  - Removed redundant `.claude/notepads/` line.

## Validation
- Full hook test suite:
  - `uv run --directory tests/oh-my-claude/hooks pytest -q`
  - Result: `906 passed`
- Manifest validation:
  - `claude plugin validate plugins/oh-my-claude/.claude-plugin/plugin.json`
  - `claude plugin validate .claude-plugin/marketplace.json`
  - Result: both passed
- CI-style prechecks:
  - JSON parse/version sync/no forbidden `../`/hook-script existence+executable/skill directory checks
  - Result: passed
- Shell script lint:
  - `shellcheck` across `plugins/oh-my-claude/**/*.sh`
  - Result: passed
- Hook lint:
  - `uvx ruff check` across `plugins/oh-my-claude/hooks/*.py`
  - Result: passed
- Real runtime local plugin load smoke test:
  - `claude --setting-sources project --plugin-dir "$(pwd)/plugins/oh-my-claude" -p "ultrawork ..." -d --debug-file ...`
  - Result: response `OK`; debug log confirms local plugin load and `Hook UserPromptSubmit ... success`; no hook failure/exception signatures.

## Notes
- MCP servers may emit startup banner lines on stderr that appear as `[ERROR]`; in runtime validation those were followed by successful connection/capability logs and were non-fatal.
