### PR TITLE
fix(plugin): refresh Claude Code compatibility

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "name": "TechDufus"
   },
   "metadata": {
-    "description": "Ultrawork mode for maximum parallel execution with intelligent subagent use",
+    "description": "Opinionated Claude Code plugin for ultrawork, orchestration guardrails, and review gates.",
     "version": "0.13.0"
   },
   "plugins": [
     {
       "name": "oh-my-claude",
       "source": "./plugins/oh-my-claude",
-      "description": "Add 'ultrawork' to any prompt for maximum parallel execution.",
+      "description": "Opinionated Claude Code plugin for ultrawork, orchestration guardrails, and review gates.",
       "version": "0.13.0",
       "author": {
         "name": "TechDufus"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <img src="site/public/favicon.svg" alt="oh-my-claude mascot" width="80" height="80">
 </p>
 
-<h3 align="center">Enhance Claude Code with context protection and specialized quality gates.</h3>
+<h3 align="center">Opinionated Claude Code plugin for ultrawork, orchestration guardrails, and review gates.</h3>
 
 ---
 
@@ -53,14 +53,14 @@ Claude will parallelize everything, delegate file reads to subagents, track prog
 
 ## Why This Exists
 
-Claude Code is already intelligent. oh-my-claude makes it even better by:
+Claude Code is already strong. oh-my-claude pushes it harder by:
 
-- **Protecting your context** — Delegates file reading to subagents so your main session stays sharp
+- **Coaching delegation** — Pushes heavy reading and side quests into subagents so your main session stays sharp
 - **Adding quality gates** — Specialized agents for gap analysis, plan review, and validation
 - **Working invisibly** — Hooks run in the background; you get a better experience just for having it installed
 - **Staying out of the way** — Enhances Claude's capabilities without conflicting with its built-in intelligence
 
-Install it and forget it. Your context is protected. Your plans get reviewed. Your work gets validated.
+Install it and forget it. Your plans get reviewed. Your work gets validated. Claude stays focused.
 
 ---
 
@@ -93,9 +93,9 @@ git clone https://github.com/TechDufus/oh-my-claude /tmp/oh-my-claude
 /plugin install oh-my-claude@oh-my-claude
 ```
 
-### Step 3: Restart Claude Code
+### Step 3: Reload plugins or restart Claude Code
 
-Required for hooks to activate.
+`/reload-plugins` is enough on newer Claude Code builds. Restart still works everywhere.
 
 ### Update
 
@@ -157,21 +157,23 @@ Claude Code provides these agents out of the box, which oh-my-claude leverages:
 |----------------|--------------|
 | **Explore** | Find files, search codebase, locate definitions |
 | **Plan** | Design implementation approaches, decompose complex tasks |
-| **Task** | General-purpose implementation tasks |
+| **general-purpose** | General-purpose implementation tasks |
 
 ### Usage
 
 ```
-Task(subagent_type="oh-my-claude:librarian", prompt="Summarize src/auth/service.ts")
-Task(subagent_type="oh-my-claude:risk-assessor", prompt="Assess risk for this migration plan")
-Task(subagent_type="oh-my-claude:critic", prompt="Review this implementation plan for flaws")
-Task(subagent_type="oh-my-claude:worker", prompt="Add password reset endpoint")
-Task(subagent_type="oh-my-claude:validator", prompt="Run all tests and report results")
+Agent(subagent_type="oh-my-claude:librarian", prompt="Summarize src/auth/service.ts")
+Agent(subagent_type="oh-my-claude:risk-assessor", prompt="Assess risk for this migration plan")
+Agent(subagent_type="oh-my-claude:critic", prompt="Review this implementation plan for flaws")
+Agent(subagent_type="oh-my-claude:worker", prompt="Add password reset endpoint")
+Agent(subagent_type="oh-my-claude:validator", prompt="Run all tests and report results")
 ```
 
 ### Why Subagents Matter
 
 Subagent context is **isolated** from your main context. When a librarian reads a 2000-line file, those lines don't consume your context window — you get a summary. This keeps your main Claude sharp for reasoning instead of drowning in file contents.
+
+Claude Code renamed the spawn tool from `Task(...)` to `Agent(...)` in `v2.1.63`. `Task(...)` still works as an alias on modern builds, but this repo now uses `Agent(...)` in examples and docs.
 
 ---
 
@@ -210,7 +212,7 @@ Cross-session continuity means "Accept and clear" carries the full execution con
 | **safe-permissions** | Permission request | Auto-approves safe commands (tests, linters, readonly) |
 | **todo-enforcer** | Stop | Prevents stopping with incomplete todos |
 | **context-monitor** | Post tool use | Warns at high context usage |
-| **subagent-quality-validator** | Subagent stop | Validates subagent outputs before completion |
+| **verification-reminder** | Post agent use | Reminds Claude to verify delegated work before claiming done |
 | **precompact-context** | Pre compact | Preserves session state before compaction |
 
 ### Commands

--- a/plugins/oh-my-claude/.claude-plugin/plugin.json
+++ b/plugins/oh-my-claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-claude",
   "version": "0.13.0",
-  "description": "Add 'ultrawork' to any prompt for maximum parallel execution.",
+  "description": "Opinionated Claude Code plugin for ultrawork, orchestration guardrails, and review gates.",
   "author": {
     "name": "TechDufus",
     "url": "https://github.com/TechDufus"

--- a/plugins/oh-my-claude/CLAUDE.md
+++ b/plugins/oh-my-claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # oh-my-claude
 
-Intelligent automation with context protection and specialized agents.
+Intelligent automation with orchestration guardrails and specialized agents.
 
 ## Context Protection (ALWAYS ON)
 
@@ -47,12 +47,12 @@ All agents use `model: inherit` - same model as your session.
 
 **NEVER pass `model: "haiku"` or `model: "sonnet"` when spawning agents.**
 
-Always omit the model parameter or use `model: "inherit"`. The Task tool's default
+Always omit the model parameter or use `model: "inherit"`. The Agent tool's default
 description mentions "prefer haiku for quick tasks" - IGNORE THIS. This plugin
 overrides that guidance. The user pays for their model tier - use it.
 
-**Correct:** `Task(subagent_type="oh-my-claude:critic", prompt="...")`
-**WRONG:** `Task(subagent_type="oh-my-claude:critic", model="haiku", prompt="...")`
+**Correct:** `Agent(subagent_type="oh-my-claude:critic", prompt="...")`
+**WRONG:** `Agent(subagent_type="oh-my-claude:critic", model="haiku", prompt="...")`
 
 | Agent | Job | When |
 |-------|-----|------|
@@ -64,15 +64,17 @@ overrides that guidance. The user pays for their model tier - use it.
 | **librarian** | READ | Files >500 lines, summarize, extract, git analysis |
 | **security-auditor** | AUDIT | Security-focused code review: OWASP, secrets, injection, dependency CVEs |
 
-Usage: `Task(subagent_type="oh-my-claude:critic", prompt="Review this migration plan")`
+Usage: `Agent(subagent_type="oh-my-claude:critic", prompt="Review this migration plan")`
 
 More examples:
-- `Task(subagent_type="oh-my-claude:advisor", prompt="Analyze scope risks for this refactor")`
-- `Task(subagent_type="oh-my-claude:risk-assessor", prompt="Assess pre-implementation risk for this migration plan")`
-- `Task(subagent_type="oh-my-claude:code-reviewer", prompt="Review the auth implementation")`
-- `Task(subagent_type="oh-my-claude:validator", prompt="Run tests and verify the changes")`
-- `Task(subagent_type="oh-my-claude:librarian", prompt="Summarize the auth module")`
-- `Task(subagent_type="oh-my-claude:security-auditor", prompt="Audit the auth module for security vulnerabilities")`
+- `Agent(subagent_type="oh-my-claude:advisor", prompt="Analyze scope risks for this refactor")`
+- `Agent(subagent_type="oh-my-claude:risk-assessor", prompt="Assess pre-implementation risk for this migration plan")`
+- `Agent(subagent_type="oh-my-claude:code-reviewer", prompt="Review the auth implementation")`
+- `Agent(subagent_type="oh-my-claude:validator", prompt="Run tests and verify the changes")`
+- `Agent(subagent_type="oh-my-claude:librarian", prompt="Summarize the auth module")`
+- `Agent(subagent_type="oh-my-claude:security-auditor", prompt="Audit the auth module for security vulnerabilities")`
+
+Claude Code renamed `Task(...)` to `Agent(...)` in `v2.1.63`. Use `Agent(...)` in new prompts. `TaskCreate`/`TaskUpdate`/`TaskList`/`TaskGet` stay the same.
 
 ### Agent Disambiguation (Planning + Review Agents)
 
@@ -96,11 +98,11 @@ Use Claude Code's native agents for common tasks:
 | **Plan** | PLAN | Complex tasks needing decomposition |
 | **general-purpose** | BUILD | Implementation tasks |
 
-Usage: `Task(subagent_type="Explore", prompt="Find auth files", thoroughness="medium")`
+Usage: `Agent(subagent_type="Explore", prompt="Find auth files", thoroughness="medium")`
 
 More examples:
-- `Task(subagent_type="Plan", prompt="Design the migration strategy")`
-- `Task(subagent_type="general-purpose", prompt="Implement the UserAuth class")`
+- `Agent(subagent_type="Plan", prompt="Design the migration strategy")`
+- `Agent(subagent_type="general-purpose", prompt="Implement the UserAuth class")`
 
 ## Task System (Coordination Layer)
 
@@ -125,12 +127,12 @@ TaskUpdate(taskId="2", addBlockedBy=["1"])
 
 # Agent self-discovery via owner
 TaskUpdate(taskId="1", owner="explore-1")
-Task(subagent_type="Explore", prompt="Find auth-related files...")
+Agent(subagent_type="Explore", prompt="Find auth-related files...")
 ```
 
 ### Task System: Tracking vs Execution
 
-**Key distinction:** `Task()` = spawn agent NOW. `TaskCreate()` = track work for later.
+**Key distinction:** `Agent()` = spawn agent NOW. `TaskCreate()` = track work for later.
 
 ```python
 # TRACKING: Create items to track progress
@@ -139,14 +141,14 @@ TaskCreate(subject="Write tests", description="Unit tests for auth middleware")
 TaskUpdate(taskId="2", addBlockedBy=["1"])  # Tests blocked by implementation
 
 # EXECUTION: Spawn agents to do work (parallel when independent)
-Task(subagent_type="general-purpose", prompt="Implement JWT middleware...")
-Task(subagent_type="oh-my-claude:validator", prompt="Run auth tests...")
+Agent(subagent_type="general-purpose", prompt="Implement JWT middleware...")
+Agent(subagent_type="oh-my-claude:validator", prompt="Run auth tests...")
 
 # UPDATE: Mark complete after verification
 TaskUpdate(taskId="1", status="completed")
 ```
 
-**Parallelization:** Launch multiple `Task()` calls in ONE message for parallel execution.
+**Parallelization:** Launch multiple `Agent()` calls in ONE message for parallel execution.
 
 **Escape hatch:** Add `[NO-DELEGATE]` for tasks main agent handles directly.
 
@@ -155,24 +157,24 @@ TaskUpdate(taskId="1", status="completed")
 You are the conductor. Agents play the music.
 
 - **Explore finds** -> **Librarian reads** -> **Plan designs** -> **Advisor scans** -> **Risk-assessor evaluates risk** -> **Critic reviews** -> **general-purpose implements** -> **Validator checks**
-- Launch independent agents in parallel (one message, multiple Task calls)
+- Launch independent agents in parallel (one message, multiple Agent calls)
 - Sequential when dependent: wait for Explore paths before librarian reads them
 - Declare intent before delegating: which agent, what task, expected output
 - Trust but verify: spot-check critical claims from agents
 
 | Situation | Do This |
 |-----------|---------|
-| Find files | Task(Explore) |
-| Understand code | Task(librarian) |
-| Git recon (tags, branches, commits) | Task(Explore) |
-| Git analysis (diffs, changelogs) | Task(librarian) |
-| Implement feature | Task(general-purpose) with spec |
-| Verify work | Task(validator) |
-| Gap analysis before planning | Task(advisor) |
-| Risk pass before plan approval | Task(oh-my-claude:risk-assessor) |
-| Complex task | Task(Plan) first |
-| Review plan before execution | Task(critic) |
-| Security audit | Task(oh-my-claude:security-auditor) |
+| Find files | Agent(Explore) |
+| Understand code | Agent(librarian) |
+| Git recon (tags, branches, commits) | Agent(Explore) |
+| Git analysis (diffs, changelogs) | Agent(librarian) |
+| Implement feature | Agent(general-purpose) with spec |
+| Verify work | Agent(validator) |
+| Gap analysis before planning | Agent(advisor) |
+| Risk pass before plan approval | Agent(oh-my-claude:risk-assessor) |
+| Complex task | Agent(Plan) first |
+| Review plan before execution | Agent(critic) |
+| Security audit | Agent(oh-my-claude:security-auditor) |
 
 ## Ultrawork Mode
 

--- a/plugins/oh-my-claude/agents/CLAUDE.md
+++ b/plugins/oh-my-claude/agents/CLAUDE.md
@@ -1,6 +1,6 @@
 # Agents
 
-Specialized subagent definitions for Task tool delegation.
+Specialized subagent definitions for Claude Code agent delegation.
 
 ## Structure
 
@@ -9,18 +9,9 @@ Each agent is a markdown file with YAML frontmatter:
 ```markdown
 ---
 model: inherit
-permissionMode: default           # Optional: default, plan, acceptEdits, dontAsk, bypassPermissions
-maxTokens: 4000                   # Optional: limit output length
 description: "Role phrase. Capability summary."
-tools:
-  - ToolName
-  - Bash(command:pattern)
-hooks:                            # Optional: inject prompts at execution points
-  Stop:
-    - matcher: "*"
-      hooks:
-        - type: prompt
-          prompt: "Final validation prompt"
+disallowedTools: Write, Edit      # Optional: enforce read-only behavior
+maxTurns: 10                      # Optional: cap long-running delegation
 ---
 
 # AgentName
@@ -83,7 +74,7 @@ You'll receive a specific implementation task. Examples:
 
 **NEVER pass `model: "haiku"` or `model: "sonnet"` when spawning agents.**
 
-The Task tool's default description suggests "prefer haiku for quick tasks" - IGNORE THIS.
+The Agent tool's default description suggests "prefer haiku for quick tasks" - IGNORE THIS.
 This plugin overrides that guidance. All oh-my-claude agents are defined with `model: inherit`
 in their frontmatter, and the parent session should NEVER override this with a downgrade.
 
@@ -95,135 +86,64 @@ in their frontmatter, and the parent session should NEVER override this with a d
 **When spawning agents:**
 ```yaml
 # CORRECT - inherits parent model
-Task(subagent_type="oh-my-claude:critic", prompt="...")
+Agent(subagent_type="oh-my-claude:critic", prompt="...")
 
 # CORRECT - explicit inherit
-Task(subagent_type="oh-my-claude:librarian", model="inherit", prompt="...")
+Agent(subagent_type="oh-my-claude:librarian", model="inherit", prompt="...")
 
 # WRONG - NEVER DO THIS
-Task(subagent_type="oh-my-claude:critic", model="haiku", prompt="...")
-Task(subagent_type="oh-my-claude:validator", model="sonnet", prompt="...")
+Agent(subagent_type="oh-my-claude:critic", model="haiku", prompt="...")
+Agent(subagent_type="oh-my-claude:validator", model="sonnet", prompt="...")
 ```
 
-## Permission Modes
+Claude Code renamed `Task(...)` to `Agent(...)` in `v2.1.63`. Use `Agent(...)` in new examples. `Task(...)` remains an alias on modern builds.
 
-Control how the agent handles permission prompts via the `permissionMode` frontmatter field.
+## Plugin Agent Limits
 
-| Mode | Behavior | Use Case |
-|------|----------|----------|
-| `default` | Standard permission checking | General-purpose agents, balanced safety |
-| `plan` | Read-only exploration mode | Read-only agents - information gathering only |
-| `acceptEdits` | Auto-accept file edits | Trusted implementation agents |
-| `dontAsk` | Auto-deny permission prompts | Strict read-only agents, reviewers |
-| `bypassPermissions` | Skip all permission checks | Dangerous - use only for fully trusted automation |
+Plugin-provided agents are not full project agents. Current Claude Code ignores some frontmatter fields when an agent comes from a plugin.
 
-**Guidelines:**
-- Read-only agents (librarian): use `plan` or `dontAsk`
-- Review agents (advisor, risk-assessor, critic): use `plan` to prevent accidental changes
-- Validation agents (validator): use `plan` for safety, full Bash for test execution
-- Never use `bypassPermissions` unless explicitly required by workflow
+Ignored on plugin agents:
+- `permissionMode`
+- agent-local `hooks`
+- agent-local `mcpServers`
+
+Use supported fields instead:
+- `tools` / `disallowedTools` to control capabilities
+- `model` to pin or inherit model choice
+- `memory`, `skills`, `maxTurns`, `color` when needed
+
+If you need `permissionMode` or agent-local hooks, copy the agent into `.claude/agents/` or `~/.claude/agents/`.
 
 ```yaml
 ---
 model: inherit
-permissionMode: plan
 description: "Read-only reconnaissance agent."
-tools:
-  - Read
-  - Glob
-  - Grep
+disallowedTools: Write, Edit
 ---
 ```
 
-## Hooks Patterns
+## Turn Limits
 
-Agents can define hooks to inject prompts or validation at specific execution points.
-
-### Hook Types
-
-| Hook | Trigger | Purpose |
-|------|---------|---------|
-| `PreToolUse` | Before tool execution | Validate inputs, inject guidance |
-| `PostToolUse` | After tool execution | Process results, extract data |
-| `Stop` | Agent completion | Enforce output format, final validation |
-
-### PreToolUse Example
-
-Inject verification before file modifications:
-
-```yaml
-hooks:
-  PreToolUse:
-    - matcher: "Edit|Write"
-      hooks:
-        - type: prompt
-          prompt: "Verify this change aligns with the task scope before proceeding."
-```
-
-### PostToolUse Example
-
-Process tool output for specific patterns:
-
-```yaml
-hooks:
-  PostToolUse:
-    - matcher: "Bash"
-      hooks:
-        - type: prompt
-          prompt: "Check for errors in command output. If errors found, document them."
-```
-
-### Stop Example
-
-Enforce structured output format:
-
-```yaml
-hooks:
-  Stop:
-    - matcher: "*"
-      hooks:
-        - type: prompt
-          prompt: |
-            Before completing, ensure your response includes:
-            1. A VERDICT line (PASS/FAIL/NEEDS_REVIEW)
-            2. Summary of findings
-            3. Specific file paths for any issues found
-```
-
-### Matcher Patterns
-
-| Pattern | Matches |
-|---------|---------|
-| `*` | All tools |
-| `Edit` | Edit tool only |
-| `Edit\|Write` | Edit OR Write tools |
-| `Bash` | Bash tool |
-
-## Output Constraints
-
-Control token limits via `maxTokens` in frontmatter for agents with specific output requirements.
+Control long-running delegation with `maxTurns` in frontmatter.
 
 | Agent Type | Recommended Limit | Rationale |
 |------------|-------------------|-----------|
-| Explore | 2000-4000 | Returns locations, not content |
-| Librarian | 4000-8000 | Summaries should be concise |
-| Critic | 4000-6000 | Focused feedback, not rewrites |
-| Validator | 4000-6000 | Results + brief explanation |
-| Advisor | 4000-6000 | Guidance should be concise |
+| Explore | 4-8 | Search, summarize, stop |
+| Librarian | 6-12 | Read several files, return concise summary |
+| Critic | 4-8 | Focused feedback, not rewrites |
+| Validator | 6-12 | Run checks, report verdict |
+| Advisor | 4-8 | Surface gaps without sprawling |
 
-**When to use output constraints:**
-- Agents that tend to over-explain or dump content
-- Read-only agents returning locations instead of content
-- Review agents that should give feedback, not implementations
+**When to use turn limits:**
+- Agents that can spiral on wide searches
+- Validators that might keep retrying failing commands
+- Review agents that should return findings, not over-investigate
 
 ```yaml
 ---
 model: inherit
-maxTokens: 4000
+maxTurns: 8
 description: "Concise reconnaissance agent."
-tools:
-  - Glob
-  - Grep
 ---
 ```
 
@@ -234,11 +154,8 @@ which is governed by Claude Code's built-in permission system (settings.json,
 permission modes, PermissionRequest hooks). This avoids a redundant restriction
 layer that causes unnecessary permission prompts.
 
-Use `permissionMode` to control agent behavior instead:
-- `plan` — read-only agents (critic, advisor, risk-assessor, librarian, code-reviewer, security-auditor)
-- `default` — standard agents
-
-Only add explicit `tools` if you need to restrict beyond what `permissionMode` provides.
+For plugin agents, prefer `disallowedTools: Write, Edit` for read-only roles.
+Only add explicit `tools` if you need to narrow capabilities further than that.
 
 ## Description Pattern
 
@@ -250,11 +167,11 @@ Examples:
 
 ## Agent Tiers
 
-| Tier | Agents | Permission Mode |
-|------|--------|-----------------|
-| Read-only | librarian | plan |
-| Review | critic, code-reviewer, advisor, risk-assessor, security-auditor | plan |
-| Execution | validator | default (inherits parent) |
+| Tier | Agents | Runtime guardrail |
+|------|--------|------------------|
+| Read-only | librarian | `disallowedTools: Write, Edit` |
+| Review | critic, code-reviewer, advisor, risk-assessor, security-auditor | `disallowedTools: Write, Edit` |
+| Execution | validator | `disallowedTools: Write, Edit` plus prompt-level "report only" rules |
 
 **Note:** Use Claude Code's built-in agents for common tasks:
 - **Explore** - File/definition discovery
@@ -329,7 +246,7 @@ Claude Code has built-in Task API documentation. Focus on small, validateable ta
 
 ## Anti-Patterns
 
-- Don't add explicit `tools` unless `permissionMode` is insufficient
+- Don't add unsupported plugin-only expectations like `permissionMode` or agent-local `hooks`
 - Don't omit "What Agent Does NOT Do" section
 - Don't use vague descriptions
-- Don't duplicate Claude Code's permission system with agent-level restrictions
+- Don't duplicate Claude Code's permission system with sprawling tool allowlists unless you need them

--- a/plugins/oh-my-claude/agents/advisor.md
+++ b/plugins/oh-my-claude/agents/advisor.md
@@ -2,7 +2,7 @@
 model: inherit
 memory: project
 description: "Mission-first pre-plan advisor that surfaces hidden requirements, assumptions, missing context, and scope risk before planning."
-permissionMode: plan
+disallowedTools: Write, Edit
 ---
 
 # Advisor

--- a/plugins/oh-my-claude/agents/code-reviewer.md
+++ b/plugins/oh-my-claude/agents/code-reviewer.md
@@ -2,7 +2,7 @@
 model: inherit
 memory: project
 description: "Use this agent to review implemented code for requirement fit, quality, and risk before completion."
-permissionMode: plan
+disallowedTools: Write, Edit
 ---
 
 # Code Reviewer

--- a/plugins/oh-my-claude/agents/critic.md
+++ b/plugins/oh-my-claude/agents/critic.md
@@ -2,7 +2,7 @@
 model: inherit
 memory: project
 description: "Mission-first plan critic that stress-tests execution readiness with concrete evidence and actionable fixes."
-permissionMode: plan
+disallowedTools: Write, Edit
 ---
 
 # Critic

--- a/plugins/oh-my-claude/agents/librarian.md
+++ b/plugins/oh-my-claude/agents/librarian.md
@@ -2,7 +2,7 @@
 model: inherit
 memory: project
 description: "Context-efficient reader and summarizer for files and git history with selective extraction and concise, evidence-first reporting."
-permissionMode: plan
+disallowedTools: Write, Edit
 ---
 
 # Librarian

--- a/plugins/oh-my-claude/agents/risk-assessor.md
+++ b/plugins/oh-my-claude/agents/risk-assessor.md
@@ -2,7 +2,7 @@
 model: inherit
 memory: project
 description: "Autonomous cross-stack change-risk assessor for planning and PR review. Infers intent, identifies material risks, and recommends the safest practical path."
-permissionMode: plan
+disallowedTools: Write, Edit
 ---
 
 # Risk Assessor

--- a/plugins/oh-my-claude/agents/security-auditor.md
+++ b/plugins/oh-my-claude/agents/security-auditor.md
@@ -2,7 +2,7 @@
 model: inherit
 memory: project
 description: "High-signal security reviewer for exploitable code risks, read-only analysis, and best-effort dependency checks."
-permissionMode: plan
+disallowedTools: Write, Edit
 ---
 
 # Security Auditor

--- a/plugins/oh-my-claude/agents/validator.md
+++ b/plugins/oh-my-claude/agents/validator.md
@@ -2,12 +2,7 @@
 model: inherit
 memory: project
 description: "Mission-first validator that runs relevant checks, reports evidence, and returns a binary pass/fail verdict with next steps."
-hooks:
-  Stop:
-    - matcher: "*"
-      hooks:
-        - type: prompt
-          prompt: "Your response MUST end with a verdict line. If missing, add: 'VERDICT: PASS' (all checks passed) or 'VERDICT: FAIL - <reason>' (any failures). Check your response now and add the verdict if missing."
+disallowedTools: Write, Edit
 ---
 
 # Validator

--- a/plugins/oh-my-claude/commands/prime.md
+++ b/plugins/oh-my-claude/commands/prime.md
@@ -82,7 +82,7 @@ If `--quick` flag provided, STOP HERE.
 All subagents receive this wrapper structure. Replace `{AGENT_NAME}`, `{WORD_LIMIT}`, `{COMMANDS}`, `{REQUIREMENTS}`, and `{XML_FIELDS}`:
 
 ```
-Task(
+Agent(
   subagent_type: "general-purpose",
   description: "{description}",
   prompt: """

--- a/plugins/oh-my-claude/hooks/agent_usage_reminder.py
+++ b/plugins/oh-my-claude/hooks/agent_usage_reminder.py
@@ -29,7 +29,7 @@ from hook_utils import (
 DIRECT_SEARCH_TOOLS = {"Grep", "Glob"}
 
 # Tools that indicate agent usage (no reminder needed for this invocation)
-AGENT_TOOLS = {"Task"}
+AGENT_TOOLS = {"Agent", "Task"}
 
 REMINDER_MESSAGE = """[Agent Usage Reminder]
 
@@ -38,7 +38,7 @@ You used a search tool directly. Direct search = context tax. Agent search = par
 | Instead of | Use |
 |------------|-----|
 | Grep/Glob directly | Explore (built-in agent for finding files/definitions) |
-| Reading large files (>500 lines) | Task(subagent_type="oh-my-claude:librarian") |
+| Reading large files (>500 lines) | Agent(subagent_type="oh-my-claude:librarian") |
 
 For large file reads, delegate to librarian — it reads the full file and returns only what matters.
 

--- a/plugins/oh-my-claude/hooks/context_guardian.py
+++ b/plugins/oh-my-claude/hooks/context_guardian.py
@@ -49,7 +49,7 @@ Your context window is for REASONING, not storage. Subagent context is FREE.
 | **Plan** | DESIGN | Complex task decomposition |
 | **general-purpose** | BUILD | Implementation tasks |
 
-Usage: `Explore` for finding, `Task(subagent_type="oh-my-claude:librarian", prompt="...")` for large files
+Usage: `Explore` for finding, `Agent(subagent_type="oh-my-claude:librarian", prompt="...")` for large files
 
 ## Delegation Protocol
 
@@ -71,13 +71,13 @@ Explore finds → Librarian reads → You reason → Agents implement → Valida
 
 ## Task System (Coordination Layer)
 
-**Key distinction:** `Task()` = spawn agent NOW. `TaskCreate()` = track work for later.
+**Key distinction:** `Agent()` = spawn agent NOW. `TaskCreate()` = track work for later.
 
 For multi-step work, use TaskCreate/TaskUpdate/TaskList to coordinate:
 
 - **Small tasks:** Each task should be atomic and independently validateable
-- **Delegate:** Spawn agents via Task() to do the actual work
-- **Parallelize:** Launch independent Task() calls in ONE message
+- **Delegate:** Spawn agents via Agent() to do the actual work
+- **Parallelize:** Launch independent Agent() calls in ONE message
 - **Dependencies:** Use addBlockedBy/addBlocks to model task ordering
 
 ## Hard Constraints

--- a/plugins/oh-my-claude/hooks/delegation_enforcer.py
+++ b/plugins/oh-my-claude/hooks/delegation_enforcer.py
@@ -47,8 +47,8 @@ DELEGATION_REMINDER = """[DELEGATION REMINDER] You're editing directly in main c
 Delegation preserves your context for reasoning. Direct edits consume tokens that could fuel orchestration.
 
 Consider delegating to:
-- Task(subagent_type='oh-my-claude:general-purpose', prompt='...')
-- Task(subagent_type='general-purpose', prompt='...')
+- Agent(subagent_type='oh-my-claude:general-purpose', prompt='...')
+- Agent(subagent_type='general-purpose', prompt='...')
 
 "It's just a tiny edit" → Context accumulates. Tiny edits compound.
 "I can do this faster myself" → Speed in tokens, not keystrokes. Delegates run while you think.
@@ -59,8 +59,8 @@ TEAM_LEAD_REMINDER = """[DELEGATION REMINDER] You're editing directly in main co
 Delegation preserves your context for reasoning. Direct edits consume tokens that could fuel orchestration.
 
 Consider delegating via teammates or subagents:
-- Task(subagent_type='oh-my-claude:general-purpose', prompt='...')
-- Task(subagent_type='general-purpose', prompt='...')
+- Agent(subagent_type='oh-my-claude:general-purpose', prompt='...')
+- Agent(subagent_type='general-purpose', prompt='...')
 - Or delegate via teammates for parallel collaboration
 
 "It's just a tiny edit" → Context accumulates. Tiny edits compound.

--- a/plugins/oh-my-claude/hooks/hooks.json
+++ b/plugins/oh-my-claude/hooks/hooks.json
@@ -211,7 +211,7 @@
         ]
       },
       {
-        "matcher": "^Task$",
+        "matcher": "^Agent$|^Task$",
         "hooks": [
           {
             "type": "command",

--- a/plugins/oh-my-claude/hooks/plan_execution_injector.py
+++ b/plugins/oh-my-claude/hooks/plan_execution_injector.py
@@ -53,7 +53,7 @@ parallel tasks that benefit from inter-agent discussion.
 
 1. `TeamCreate(team_name="descriptive-name")` — create the team
 2. `TaskCreate(subject, description, activeForm)` — create tasks for each work item
-3. `Task(subagent_type="general-purpose", team_name="descriptive-name", name="role")` — spawn teammates
+3. `Agent(subagent_type="general-purpose", team_name="descriptive-name", name="role")` — spawn teammates
 4. `TaskUpdate(taskId, owner="role")` — assign tasks to teammates
 5. Monitor via `TaskList()` and communicate via `SendMessage(recipient="role")`
 
@@ -89,7 +89,7 @@ Your plan has been approved. When you return to execute:
 
 1. **Create team** - `TeamCreate(team_name="...")` with a descriptive name
 2. **Create tasks** - `TaskCreate(...)` for EACH plan item with descriptions
-3. **Spawn teammates** - `Task(subagent_type="general-purpose", team_name="...", name="role")` per role
+3. **Spawn teammates** - `Agent(subagent_type="general-purpose", team_name="...", name="role")` per role
 4. **Assign work** - `TaskUpdate(taskId, owner="role")` to assign tasks to teammates
 5. **Monitor + verify** - `TaskList()` to track progress, run validation after changes
 6. **Do NOT deviate** - The plan was researched and approved""")

--- a/plugins/oh-my-claude/hooks/todo_enforcer.py
+++ b/plugins/oh-my-claude/hooks/todo_enforcer.py
@@ -91,8 +91,8 @@ def analyze_transcript(transcript: list[dict[str, Any]], max_entries: int = 1000
 
         # Check for validation triggers
         if not result["validation_ran"]:
-            # Check Task tool with validator
-            if entry_type == "tool_use" and entry.get("tool") == "Task":
+            # Check Agent/Task tool with validator
+            if entry_type == "tool_use" and entry.get("tool") in {"Agent", "Task"}:
                 input_data = entry.get("input") or {}
                 input_str = str(input_data).lower()
                 if "validator" in input_str:
@@ -314,7 +314,7 @@ If you have open tasks, consider these approaches:
 **Parallel work:** Delegate to agents with owner assignment:
 ```
 TaskUpdate(taskId="1", owner="agent-a")
-Task(subagent_type="general-purpose", prompt="You are agent-a. Find your tasks via TaskList...")
+Agent(subagent_type="general-purpose", prompt="You are agent-a. Find your tasks via TaskList...")
 ```
 
 **Blocked tasks:** Check if blocking tasks are complete, then proceed with unblocked work.

--- a/plugins/oh-my-claude/hooks/ultrawork_detector.py
+++ b/plugins/oh-my-claude/hooks/ultrawork_detector.py
@@ -93,8 +93,8 @@ Understand the codebase context BEFORE asking questions. Launch Explore agents t
 the lay of the land so you can ask INFORMED questions (not generic ones).
 
 ```
-Task(subagent_type="Explore", prompt="Find files relevant to {request topic}", thoroughness="quick")
-Task(subagent_type="oh-my-claude:librarian", prompt="Summarize architecture/patterns in {area}")
+Agent(subagent_type="Explore", prompt="Find files relevant to {request topic}", thoroughness="quick")
+Agent(subagent_type="oh-my-claude:librarian", prompt="Summarize architecture/patterns in {area}")
 ```
 
 Goal: learn enough to ask smart questions. NOT enough to write a plan.
@@ -145,8 +145,8 @@ Effort Estimate: {Quick | Short | Medium | Large | XL}
 Now do thorough research informed by both recon AND interview answers:
 
 ```
-Task(subagent_type="Explore", prompt="Find ALL files, deps, call sites for {scope}", thoroughness="medium")
-Task(subagent_type="oh-my-claude:librarian", prompt="Read {specific files} for {specific details}")
+Agent(subagent_type="Explore", prompt="Find ALL files, deps, call sites for {scope}", thoroughness="medium")
+Agent(subagent_type="oh-my-claude:librarian", prompt="Read {specific files} for {specific details}")
 ```
 
 This round is targeted — you know what to look for from Steps 1-2.
@@ -156,7 +156,7 @@ This round is targeted — you know what to look for from Steps 1-2.
 After deep research, MUST run the advisor before writing any plan:
 
 ```
-Task(subagent_type="oh-my-claude:advisor", prompt=\"\"\"
+Agent(subagent_type="oh-my-claude:advisor", prompt=\"\"\"
 Analyze for hidden requirements, scope risks, AI-slop patterns.
 Interview notes: {summary from Step 2}
 Research findings: {key discoveries from Step 3}
@@ -200,13 +200,13 @@ Populate the Big Picture Intent section by pulling from your interview notes (Or
 
 | Tool | Purpose | When to Use |
 |------|---------|-------------|
-| `Task()` | Spawn subagent | Research (Explore, librarian), implementation (general-purpose), validation (validator) |
+| `Agent()` | Spawn subagent | Research (Explore, librarian), implementation (general-purpose), validation (validator) |
 | `TaskCreate()` | Create tracking item | Building the task list for multi-step work |
 | `TaskUpdate()` | Update task state | Status changes, dependencies, ownership |
 | `TaskList()` | View all tasks | Check progress, find unblocked work |
 | `TaskGet()` | Get task details | Before starting work on a specific task |
 
-**Key distinction:** `Task()` = spawn agent NOW. `TaskCreate()` = track work for later.
+**Key distinction:** `Agent()` = spawn agent NOW. `TaskCreate()` = track work for later.
 
 **Note:** If agent teams are available, consider whether independent tasks benefit from inter-agent discussion. See EXECUTION STRATEGY below.
 
@@ -258,7 +258,7 @@ Each implementation task SHOULD specify what to validate. The executor decides H
 MUST submit plan to critic before ExitPlanMode:
 
 ```
-Task(subagent_type="oh-my-claude:critic", prompt=\"\"\"
+Agent(subagent_type="oh-my-claude:critic", prompt=\"\"\"
 Review this plan for clarity, completeness, correctness, executability.
 Interview decisions: {from Step 2}
 Advisor findings: {from Step 4}
@@ -286,7 +286,7 @@ Choose the right execution approach based on task characteristics:
 
 ### Default: Subagents (Task tool)
 
-Most plans execute best with subagents. Each `Task()` call spawns a focused subagent
+Most plans execute best with subagents. Each `Agent()` call spawns a focused subagent
 that reports results back. Lower token cost, simpler coordination.
 
 ### Agent Teams
@@ -294,7 +294,7 @@ that reports results back. Lower token cost, simpler coordination.
 When available, create teams using explicit tool calls:
 1. `TeamCreate(team_name="descriptive-name")` — always first
 2. `TaskCreate(...)` for each work item
-3. `Task(subagent_type="general-purpose", team_name="descriptive-name", name="role")` per teammate
+3. `Agent(subagent_type="general-purpose", team_name="descriptive-name", name="role")` per teammate
 4. `TaskUpdate(taskId, owner="role")` to assign work
 
 Agent teams create full Claude Code sessions that communicate via shared task list
@@ -328,7 +328,7 @@ You have an approved plan. Before ANY implementation:
 2. Use TaskUpdate to set blockedBy dependencies
 3. Run TaskList to confirm tasks exist
 
-**Key distinction:** `Task()` = spawn agent NOW. `TaskCreate()` = track work for later.
+**Key distinction:** `Agent()` = spawn agent NOW. `TaskCreate()` = track work for later.
 
 DO NOT spawn subagents or start implementation until tasks are created.
 
@@ -444,7 +444,7 @@ This round is targeted - you know what to look for from Steps 1-2.
 After deep research, MUST run the advisor before writing any plan:
 
 ```
-Task(subagent_type="oh-my-claude:advisor", prompt=\"\"\"
+Agent(subagent_type="oh-my-claude:advisor", prompt=\"\"\"
 Analyze for hidden requirements, scope risks, AI-slop patterns.
 Interview notes: {summary from Step 2}
 Research findings: {key discoveries from Step 3}
@@ -537,7 +537,7 @@ Each implementation task SHOULD specify what to validate. The executor decides H
 MUST submit plan to critic before ExitPlanMode:
 
 ```
-Task(subagent_type="oh-my-claude:critic", prompt=\"\"\"
+Agent(subagent_type="oh-my-claude:critic", prompt=\"\"\"
 Review this plan for clarity, completeness, correctness, executability.
 Interview decisions: {from Step 2}
 Advisor findings: {from Step 4}
@@ -565,7 +565,7 @@ Do NOT skip critic. Do NOT ExitPlanMode without critic approval.
 1. `TeamCreate(team_name="feature-x")` — create the team
 2. `TaskCreate(...)` for each plan item — build the task list
 3. `TaskUpdate(taskId, addBlockedBy=[...])` — set dependencies
-4. `Task(subagent_type="general-purpose", team_name="feature-x", name="implementer")` — spawn each teammate
+4. `Agent(subagent_type="general-purpose", team_name="feature-x", name="implementer")` — spawn each teammate
 5. `TaskUpdate(taskId, owner="implementer")` — assign tasks to teammates
 
 ## EXECUTION STRATEGY
@@ -584,7 +584,7 @@ Default to teams for independent parallel work. Use subagents for sequential or 
 Create teams using explicit tool calls:
 1. `TeamCreate(team_name="descriptive-name")` — always first
 2. `TaskCreate(...)` for each work item
-3. `Task(subagent_type="general-purpose", team_name="descriptive-name", name="role")` per teammate
+3. `Agent(subagent_type="general-purpose", team_name="descriptive-name", name="role")` per teammate
 4. `TaskUpdate(taskId, owner="role")` to assign work
 
 Use **delegate mode** (Shift+Tab) to keep the lead coordination-only.
@@ -613,7 +613,7 @@ You have an approved plan. Before ANY implementation:
 1. `TeamCreate(team_name="plan-name")` — create the team first
 2. `TaskCreate(subject, description, activeForm)` for EACH plan item
 3. `TaskUpdate(taskId, addBlockedBy=[...])` to set dependencies between tasks
-4. `Task(subagent_type="general-purpose", team_name="plan-name", name="role")` to spawn each teammate
+4. `Agent(subagent_type="general-purpose", team_name="plan-name", name="role")` to spawn each teammate
 5. `TaskUpdate(taskId, owner="role")` to assign tasks to teammates
 6. `TaskList()` to confirm everything is wired up
 
@@ -694,7 +694,7 @@ Match your team to the work type:
 Create teams using explicit tool calls:
 1. `TeamCreate(team_name="descriptive-name")` — always first
 2. `TaskCreate(...)` for each work item
-3. `Task(subagent_type="general-purpose", team_name="descriptive-name", name="role")` per teammate
+3. `Agent(subagent_type="general-purpose", team_name="descriptive-name", name="role")` per teammate
 4. `TaskUpdate(taskId, owner="role")` to assign work
 
 ### Team Rules
@@ -770,7 +770,7 @@ When assigning work to teammates:
 
 ## EXECUTION RULES
 
-1. PARALLELIZE - `TeamCreate` first, then `Task(team_name, name)` to spawn teammates for independent work
+1. PARALLELIZE - `TeamCreate` first, then `Agent(team_name, name)` to spawn teammates for independent work
 2. TRACK - `TaskCreate` for each work item, `TaskUpdate` to assign owners and track status
 3. NEVER STOP - Stopping requires passing checklist
 4. NO QUESTIONS - Decide and document
@@ -1049,11 +1049,11 @@ NEVER downgrade models. Omit `model` param or use `model="inherit"`.
 
 **Parallel patterns:** Explore+librarian (research) -> Plan->critic->general-purpose (impl) -> validator (verify)
 
-**Agent teams:** Consider teams for tasks needing inter-agent discussion. Use `TeamCreate` + `Task(team_name, name)` to create teams. Subagents remain the default for focused work.
+**Agent teams:** Consider teams for tasks needing inter-agent discussion. Use `TeamCreate` + `Agent(team_name, name)` to create teams. Subagents remain the default for focused work.
 
 ## TASK TRACKING
 
-**Key distinction:** `Task()` = spawn agent NOW. `TaskCreate()` = track work for later.
+**Key distinction:** `Agent()` = spawn agent NOW. `TaskCreate()` = track work for later.
 
 ```
 TaskCreate(subject="Action verb: description", description="Full context")
@@ -1089,7 +1089,7 @@ Tasks should be **small and atomic**. If a task touches multiple concerns, split
 
 ## EXECUTION RULES
 
-1. PARALLELIZE - Multiple Task() calls in ONE message
+1. PARALLELIZE - Multiple Agent() calls in ONE message
 2. TRACK - Use TaskCreate for multi-step work, update status real-time
 3. NEVER STOP - Stopping requires passing checklist
 4. NO QUESTIONS - Decide and document
@@ -1308,7 +1308,7 @@ Recent changes statistically likely to contain bugs.
 ## Escalation (After 2+ Failed Attempts)
 
 ```
-Task(subagent_type="Explore", prompt="
+Agent(subagent_type="Explore", prompt="
 PROBLEM: {error + conditions}
 ATTEMPTED: 1. {tried} - {failed why}  2. {tried} - {failed why}
 HYPOTHESES: H1: {hyp} - {result}  H2: {hyp} - {result}

--- a/plugins/oh-my-claude/hooks/verification_reminder.py
+++ b/plugins/oh-my-claude/hooks/verification_reminder.py
@@ -5,7 +5,7 @@
 # ///
 """
 verification_reminder.py
-PostToolUse hook: Reminds Claude to verify agent claims after Task completion.
+PostToolUse hook: Reminds Claude to verify agent claims after Agent/Task completion.
 """
 
 from pathlib import Path
@@ -58,8 +58,8 @@ def main() -> None:
 
     log_debug(f"tool_name={tool_name}")
 
-    if tool_name == "Task":
-        log_debug("Task completed, injecting verification reminder")
+    if tool_name in {"Agent", "Task"}:
+        log_debug("Agent completed, injecting verification reminder")
         output_context("PostToolUse", VERIFICATION_MESSAGE)
     else:
         return output_empty()

--- a/plugins/oh-my-claude/skills/git-commit-validator/SKILL.md
+++ b/plugins/oh-my-claude/skills/git-commit-validator/SKILL.md
@@ -236,7 +236,7 @@ Problem: Agents were receiving prompts without project context,
 leading to inconsistent code style and missed conventions.
 
 Solution: SessionStart hook now injects a delegation template
-into Claude's context that gets included with every Task() call.
+into Claude's context that gets included with every Agent() call.
 
 Template includes:
 - 7 sections covering task, context, expected output

--- a/site/src/components/HowItWorks.astro
+++ b/site/src/components/HowItWorks.astro
@@ -11,8 +11,8 @@ const steps = [
   {
     step: 2,
     title: "Agents swarm",
-    description: "Built-in Explore finds files. Librarian reads them. Plan mode designs. Tasks implement. Your context window never sees the raw dump.",
-    snippet: "Explore → librarian → Plan → Task",
+    description: "Built-in Explore finds files. Librarian reads them. Plan mode designs. Agent calls implement. Your context window never sees the raw dump.",
+    snippet: "Explore → librarian → Plan → Agent",
     icon: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>`,
   },
   {

--- a/site/src/components/UseCases.astro
+++ b/site/src/components/UseCases.astro
@@ -18,8 +18,8 @@ const useCases = [
     description: "Describe what you want. The agent swarm handles the rest while you review.",
     terminal: [
       "Plan mode → 5-step plan created",
-      "Task[1] → src/routes/auth.ts written",
-      "Task[2] → src/middleware/jwt.ts written",
+      "Agent[1] → src/routes/auth.ts written",
+      "Agent[2] → src/middleware/jwt.ts written",
       "validator → all 12 tests passing",
     ],
     accent: "coral" as const,
@@ -30,7 +30,7 @@ const useCases = [
     terminal: [
       "ultradebug → root cause: race condition",
       "  in useEffect cleanup on unmount",
-      "Task → fix applied to 2 files",
+      "Agent → fix applied to 2 files",
       "validator → regression suite green",
     ],
     accent: "cyan" as const,

--- a/site/src/content/copy.ts
+++ b/site/src/content/copy.ts
@@ -4,7 +4,7 @@
 
 // ── Hero ────────────────────────────────────────────────────────
 export const heroHeadline = "Stop Wasting Your Context Window"
-export const heroTagline = "A Claude Code plugin that delegates file reading, searching, and implementation to specialized agents — so your main session stays sharp."
+export const heroTagline = "A Claude Code plugin that adds orchestration guardrails, review gates, and ultrawork so your main session stays sharp."
 
 // ── Stats Bar ───────────────────────────────────────────────────
 export const stats = [
@@ -26,8 +26,8 @@ export const howItWorksSteps = [
   {
     step: 2,
     title: "Agents swarm",
-    description: "Built-in Explore finds files. Librarian reads them. Plan mode designs. Tasks implement. Your context window never sees the raw dump.",
-    snippet: "Explore → librarian → Plan → Task",
+    description: "Built-in Explore finds files. Librarian reads them. Plan mode designs. Agent calls implement. Your context window never sees the raw dump.",
+    snippet: "Explore → librarian → Plan → Agent",
   },
   {
     step: 3,
@@ -53,8 +53,8 @@ Plan mode → dependency graph built
     title: "Implementing a Feature",
     description: "Describe what you want. The agent swarm handles the rest while you review.",
     terminal: `Plan mode → 5-step plan created
-Task[1] → src/routes/auth.ts written
-Task[2] → src/middleware/jwt.ts written
+Agent[1] → src/routes/auth.ts written
+Agent[2] → src/middleware/jwt.ts written
 validator → all 12 tests passing`,
     accent: "coral",
   },
@@ -63,7 +63,7 @@ validator → all 12 tests passing`,
     description: "When you're stuck after two attempts, use ultradebug skill for deep reasoning you shouldn't burn context on.",
     terminal: `ultradebug → root cause: race condition
   in useEffect cleanup on unmount
-Task → fix applied to 2 files
+Agent → fix applied to 2 files
 validator → regression suite green`,
     accent: "cyan",
   },

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -19,11 +19,11 @@ import MagneticButton from '@/components/MagneticButton'
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Claude Code plugin for context protection, specialized agents, and ultrawork mode. Enhance your AI coding workflow.">
+  <meta name="description" content="Claude Code plugin for ultrawork, orchestration guardrails, and review gates.">
 
   <!-- Open Graph -->
   <meta property="og:title" content="oh-my-claude">
-  <meta property="og:description" content="The definitive Claude Code plugin. Context protection, specialized agents, and ultrawork mode.">
+  <meta property="og:description" content="The definitive Claude Code plugin. Ultrawork, orchestration guardrails, and review gates.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://oh-my-claude.techdufus.com">
   <meta property="og:image" content="https://oh-my-claude.techdufus.com/og-image.png">
@@ -33,7 +33,7 @@ import MagneticButton from '@/components/MagneticButton'
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="oh-my-claude">
-  <meta name="twitter:description" content="The definitive Claude Code plugin. Context protection, specialized agents, and ultrawork mode.">
+  <meta name="twitter:description" content="The definitive Claude Code plugin. Ultrawork, orchestration guardrails, and review gates.">
   <meta name="twitter:image" content="https://oh-my-claude.techdufus.com/og-image.png">
 
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
@@ -70,8 +70,8 @@ import MagneticButton from '@/components/MagneticButton'
             <span class="text-cyan">Context Window</span>
           </h1>
           <p class="text-lg md:text-xl text-muted-foreground mb-8">
-            A Claude Code plugin that delegates file reading, searching, and implementation
-            to specialized agents — so your main session stays sharp.
+            A Claude Code plugin that adds orchestration guardrails, review gates, and ultrawork
+            so your main session stays sharp.
           </p>
           <InstallBlock client:load />
         </div>
@@ -134,7 +134,7 @@ import MagneticButton from '@/components/MagneticButton'
             $ curl -LsSf https://astral.sh/uv/install.sh | sh<br>
             $ claude plugin marketplace add techdufus/oh-my-claude<br>
             $ claude plugin install oh-my-claude@oh-my-claude<br>
-            <span class="text-cyan">→ Plugin installed. Context protection active.</span>
+            <span class="text-cyan">→ Plugin installed. Guardrails active.</span>
           </p>
         </div>
       </div>

--- a/tests/oh-my-claude/hooks/test_agent_usage_reminder.py
+++ b/tests/oh-my-claude/hooks/test_agent_usage_reminder.py
@@ -116,6 +116,12 @@ class TestTaskSuppressesReminder:
         context = get_context(output)
         assert context == ""
 
+    def test_agent_tool_no_output(self):
+        """Agent tool should also suppress reminder."""
+        output = run_hook({"tool_name": "Agent", "session_id": "test-agent-1"})
+        context = get_context(output)
+        assert context == ""
+
 
 class TestSessionTracking:
     """Tests for session tracking behavior."""

--- a/tests/oh-my-claude/hooks/test_todo_enforcer.py
+++ b/tests/oh-my-claude/hooks/test_todo_enforcer.py
@@ -197,6 +197,18 @@ class TestAnalyzeTranscript:
         result = analyze_transcript(transcript)
         assert result["validation_ran"] is True
 
+    def test_detects_validation_in_agent_tool(self):
+        """Should detect validator in Agent tool input too."""
+        transcript = [
+            {
+                "type": "tool_use",
+                "tool": "Agent",
+                "input": {"subagent_type": "oh-my-claude:validator"},
+            },
+        ]
+        result = analyze_transcript(transcript)
+        assert result["validation_ran"] is True
+
     def test_detects_validation_in_assistant_message(self):
         """Should detect validation mention in assistant message."""
         transcript = [

--- a/tests/oh-my-claude/hooks/test_verification_reminder.py
+++ b/tests/oh-my-claude/hooks/test_verification_reminder.py
@@ -56,6 +56,12 @@ class TestTaskTriggersReminder:
         context = get_context(output)
         assert "Agent context is isolated" in context
 
+    def test_agent_triggers_reminder(self):
+        """Agent tool should trigger the same reminder as Task."""
+        output = run_hook({"tool_name": "Agent"})
+        context = get_context(output)
+        assert "Verification Required" in context
+
 
 class TestNonTaskToolsNoOp:
     """Tests for non-Task tools returning empty."""
@@ -162,3 +168,13 @@ class TestAgentSessionSkip:
         })
         context = get_context(output)
         assert "Verification Required" in context
+
+    def test_agent_session_skips_agent_reminder(self):
+        """Agent sessions should also skip reminder for Agent tool."""
+        output = run_hook({
+            "tool_name": "Agent",
+            "agent_type": "oh-my-claude:critic",
+            "session_id": "agent-test",
+        })
+        context = get_context(output)
+        assert context == ""


### PR DESCRIPTION
## Summary
- refresh plugin behavior and docs for current Claude Code `Agent(...)` naming
- replace unsupported plugin-agent frontmatter assumptions with supported read-only guardrails
- update site copy to match the refreshed positioning and runtime examples

## Why
Claude Code has moved since this plugin's last update. The biggest drift was around `Task(...)` vs `Agent(...)`, plus plugin agents no longer honoring some frontmatter fields this repo was relying on.

## Validation
- `uv run --project tests/oh-my-claude/hooks --with pytest pytest tests/oh-my-claude/hooks/test_verification_reminder.py tests/oh-my-claude/hooks/test_agent_usage_reminder.py tests/oh-my-claude/hooks/test_todo_enforcer.py`
- `python3 -m json.tool plugins/oh-my-claude/.claude-plugin/plugin.json`
- `python3 -m json.tool .claude-plugin/marketplace.json`
