### PR TITLE
docs(site): add Agent compatibility note

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ git clone https://github.com/TechDufus/oh-my-claude /tmp/oh-my-claude
 
 `/reload-plugins` is enough on newer Claude Code builds. Restart still works everywhere.
 
+**Compatibility note:** If you're on Claude Code `<= 2.1.62`, this repo's examples use the newer `Agent(...)` name, but your build may still show `Task(...)`. Use `Task(...)` on older builds or update Claude Code.
+
 ### Update
 
 ```bash

--- a/site/src/components/InstallBlock.tsx
+++ b/site/src/components/InstallBlock.tsx
@@ -49,6 +49,9 @@ export default function InstallBlock() {
           </>
         )}
       </Button>
+      <p className="max-w-2xl text-center text-sm text-muted-foreground">
+        On Claude Code {"<="} 2.1.62, older builds may still use <code>Task(...)</code> instead of <code>Agent(...)</code>.
+      </p>
     </div>
   )
 }

--- a/site/src/content/copy.ts
+++ b/site/src/content/copy.ts
@@ -5,6 +5,7 @@
 // ── Hero ────────────────────────────────────────────────────────
 export const heroHeadline = "Stop Wasting Your Context Window"
 export const heroTagline = "A Claude Code plugin that adds orchestration guardrails, review gates, and ultrawork so your main session stays sharp."
+export const compatibilityNote = "On Claude Code <= 2.1.62, older builds may still use Task(...) instead of Agent(...)."
 
 // ── Stats Bar ───────────────────────────────────────────────────
 export const stats = [

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -136,6 +136,9 @@ import MagneticButton from '@/components/MagneticButton'
             $ claude plugin install oh-my-claude@oh-my-claude<br>
             <span class="text-cyan">→ Plugin installed. Guardrails active.</span>
           </p>
+          <p class="mt-4 text-sm text-muted-foreground">
+            On Claude Code <code>&lt;= 2.1.62</code>, use <code>Task(...)</code> where this site shows <code>Agent(...)</code>, or update Claude Code.
+          </p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add a Claude Code compatibility note for users on <= 2.1.62
- place the note in the README and visible site install surfaces
- keep the message aligned with the Agent/Task rename

## Validation
- git diff --check
- npm --prefix site run build