### PR TITLE
docs(site): remove compatibility note from CTA

### DIFF
--- a/site/src/components/InstallBlock.tsx
+++ b/site/src/components/InstallBlock.tsx
@@ -49,9 +49,6 @@ export default function InstallBlock() {
           </>
         )}
       </Button>
-      <p className="max-w-2xl text-center text-sm text-muted-foreground">
-        On Claude Code {"<="} 2.1.62, older builds may still use <code>Task(...)</code> instead of <code>Agent(...)</code>.
-      </p>
     </div>
   )
 }

--- a/site/src/content/copy.ts
+++ b/site/src/content/copy.ts
@@ -5,7 +5,6 @@
 // ── Hero ────────────────────────────────────────────────────────
 export const heroHeadline = "Stop Wasting Your Context Window"
 export const heroTagline = "A Claude Code plugin that adds orchestration guardrails, review gates, and ultrawork so your main session stays sharp."
-export const compatibilityNote = "On Claude Code <= 2.1.62, older builds may still use Task(...) instead of Agent(...)."
 
 // ── Stats Bar ───────────────────────────────────────────────────
 export const stats = [

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -136,9 +136,6 @@ import MagneticButton from '@/components/MagneticButton'
             $ claude plugin install oh-my-claude@oh-my-claude<br>
             <span class="text-cyan">→ Plugin installed. Guardrails active.</span>
           </p>
-          <p class="mt-4 text-sm text-muted-foreground">
-            On Claude Code <code>&lt;= 2.1.62</code>, use <code>Task(...)</code> where this site shows <code>Agent(...)</code>, or update Claude Code.
-          </p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- remove the compatibility note from the site CTA and install block
- keep the older Claude Code compatibility note in README only
- drop the unused draft copy entry so site copy stays aligned

## Validation
- git diff --check
- npm --prefix site run build