### PR TITLE
Add native colors to plugin agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Opinionated Claude Code plugin for ultrawork, orchestration guardrails, and review gates.",
-    "version": "0.13.0"
+    "version": "0.13.1"
   },
   "plugins": [
     {
       "name": "oh-my-claude",
       "source": "./plugins/oh-my-claude",
       "description": "Opinionated Claude Code plugin for ultrawork, orchestration guardrails, and review gates.",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "author": {
         "name": "TechDufus"
       },

--- a/plugins/oh-my-claude/.claude-plugin/plugin.json
+++ b/plugins/oh-my-claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Opinionated Claude Code plugin for ultrawork, orchestration guardrails, and review gates.",
   "author": {
     "name": "TechDufus",

--- a/plugins/oh-my-claude/agents/CLAUDE.md
+++ b/plugins/oh-my-claude/agents/CLAUDE.md
@@ -10,6 +10,7 @@ Each agent is a markdown file with YAML frontmatter:
 ---
 model: inherit
 description: "Role phrase. Capability summary."
+color: cyan                      # Optional: red, blue, green, yellow, purple, orange, pink, cyan
 disallowedTools: Write, Edit      # Optional: enforce read-only behavior
 maxTurns: 10                      # Optional: cap long-running delegation
 ---
@@ -69,6 +70,7 @@ You'll receive a specific implementation task. Examples:
 |-------|-------|-------|
 | `model` | `inherit` | Uses session's model |
 | `description` | string | 1-2 sentences, quoted |
+| `color` | named color | Display color in task list and transcript |
 
 ## Model Inheritance (CRITICAL)
 
@@ -112,12 +114,15 @@ Use supported fields instead:
 - `model` to pin or inherit model choice
 - `memory`, `skills`, `maxTurns`, `color` when needed
 
+Supported agent colors: `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan`.
+
 If you need `permissionMode` or agent-local hooks, copy the agent into `.claude/agents/` or `~/.claude/agents/`.
 
 ```yaml
 ---
 model: inherit
 description: "Read-only reconnaissance agent."
+color: cyan
 disallowedTools: Write, Edit
 ---
 ```
@@ -144,6 +149,7 @@ Control long-running delegation with `maxTurns` in frontmatter.
 model: inherit
 maxTurns: 8
 description: "Concise reconnaissance agent."
+color: cyan
 ---
 ```
 
@@ -189,7 +195,7 @@ Agents work the same whether spawned by a team lead, a teammate, or a solo sessi
 ## Adding New Agent
 
 1. Create `agents/{name}.md`
-2. Add YAML frontmatter (model, description, tools)
+2. Add YAML frontmatter (model, description, color, tools)
 3. Document purpose, use cases, output format
 4. Define explicit scope boundaries
 

--- a/plugins/oh-my-claude/agents/advisor.md
+++ b/plugins/oh-my-claude/agents/advisor.md
@@ -1,6 +1,7 @@
 ---
 model: inherit
 memory: project
+color: purple
 description: "Mission-first pre-plan advisor that surfaces hidden requirements, assumptions, missing context, and scope risk before planning."
 disallowedTools: Write, Edit
 ---

--- a/plugins/oh-my-claude/agents/code-reviewer.md
+++ b/plugins/oh-my-claude/agents/code-reviewer.md
@@ -1,6 +1,7 @@
 ---
 model: inherit
 memory: project
+color: blue
 description: "Use this agent to review implemented code for requirement fit, quality, and risk before completion."
 disallowedTools: Write, Edit
 ---

--- a/plugins/oh-my-claude/agents/critic.md
+++ b/plugins/oh-my-claude/agents/critic.md
@@ -1,6 +1,7 @@
 ---
 model: inherit
 memory: project
+color: yellow
 description: "Mission-first plan critic that stress-tests execution readiness with concrete evidence and actionable fixes."
 disallowedTools: Write, Edit
 ---

--- a/plugins/oh-my-claude/agents/librarian.md
+++ b/plugins/oh-my-claude/agents/librarian.md
@@ -1,6 +1,7 @@
 ---
 model: inherit
 memory: project
+color: cyan
 description: "Context-efficient reader and summarizer for files and git history with selective extraction and concise, evidence-first reporting."
 disallowedTools: Write, Edit
 ---

--- a/plugins/oh-my-claude/agents/risk-assessor.md
+++ b/plugins/oh-my-claude/agents/risk-assessor.md
@@ -1,6 +1,7 @@
 ---
 model: inherit
 memory: project
+color: orange
 description: "Autonomous cross-stack change-risk assessor for planning and PR review. Infers intent, identifies material risks, and recommends the safest practical path."
 disallowedTools: Write, Edit
 ---

--- a/plugins/oh-my-claude/agents/security-auditor.md
+++ b/plugins/oh-my-claude/agents/security-auditor.md
@@ -1,6 +1,7 @@
 ---
 model: inherit
 memory: project
+color: red
 description: "High-signal security reviewer for exploitable code risks, read-only analysis, and best-effort dependency checks."
 disallowedTools: Write, Edit
 ---

--- a/plugins/oh-my-claude/agents/validator.md
+++ b/plugins/oh-my-claude/agents/validator.md
@@ -1,6 +1,7 @@
 ---
 model: inherit
 memory: project
+color: green
 description: "Mission-first validator that runs relevant checks, reports evidence, and returns a binary pass/fail verdict with next steps."
 disallowedTools: Write, Edit
 ---


### PR DESCRIPTION
## Summary
- add native Claude Code `color` frontmatter to each shipped oh-my-claude agent
- document the supported color palette in the agent authoring guide
- bump plugin and marketplace manifests to `0.13.1` for cache-aware plugin updates

## Validation
- `claude plugin validate .`
- `claude plugin validate plugins/oh-my-claude`
- `git diff --cached --check`

Closes #8